### PR TITLE
fixed typo in main js file, missed increment of list_id

### DIFF
--- a/quick-ng-repeat.js
+++ b/quick-ng-repeat.js
@@ -10,7 +10,7 @@ angular.module('QuickList').directive('quickNgRepeat',
   var list_id = window.list_id = (function(){
     var i = 0;
     return function(){
-      return 'list_' + i;
+      return 'list_' + (++i);
     };
   }());
 


### PR DESCRIPTION
In commit https://github.com/allaud/quick-ng-repeat/commit/b5e51acc06f620dc85f86247d8fc6c9c4cc4e9c3 referenced in issue https://github.com/allaud/quick-ng-repeat/issues/1, it looks like text was miscopied from the example quick-ng-repeat.js to the main quick-ng-repeat.js.  The iterator in `list_id` was not incremented and the update wasn't working for multiple instances of quick-ng-repeat.
