### PR TITLE
Updated classic example page to remove mentions of quick-ng-repeat

### DIFF
--- a/example/index_classic.html
+++ b/example/index_classic.html
@@ -33,7 +33,7 @@
               <h1>Classic ng-repeat example</h1>
             </div>
 
-            <div ng-repeat="item in list" quick-repeat-list="items">
+            <div ng-repeat="item in list">
                 {{ item.id }}, {{ item.fact() }}, {{ item.summ() }}, {{ item.heavy(1000) }}
             </div>
 
@@ -45,7 +45,7 @@
 
         <script src="//ajax.googleapis.com/ajax/libs/jquery/1.10.1/jquery.min.js"></script>
         <script>window.jQuery || document.write('<script src="js/vendor/jquery-1.10.1.min.js"><\/script>')</script>
-        <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.2.0-rc.3/angular.js">
+        <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.2.0-rc.3/angular.js"></script>
 
         <script src="js/vendor/bootstrap.min.js"></script>
         <script src="js/vendor/underscore.js"></script>

--- a/example/js/main_classic.js
+++ b/example/js/main_classic.js
@@ -2,7 +2,7 @@ angular.module('ListExample', ['QuickList']);
 
 angular.module('ListExample').controller('CoreController',
 
-function($scope, quickRepeatList){
+function($scope){
 
 
   var factorial = function (num){
@@ -50,7 +50,6 @@ function($scope, quickRepeatList){
 
     $scope.list = LONG_LIST.slice(0, 30 + new_to_load);
 
-    //_.defer(quickRepeatList.items, $scope.list);
     $scope.$digest();
   }), 50);
 


### PR DESCRIPTION
`example/index_classic.html` was having references of `quick-ng-repeat` which causes some confusion. Removed those references.
